### PR TITLE
Specify the exact version as preview versions of templates are not installable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Adds a basic Duende IdentityServer that uses Entity Framework for configuration 
 
 Install with:
 
-`dotnet new -i Duende.IdentityServer.Templates`
+`dotnet new --install Duende.IdentityServer.Templates::5.0.0-preview.1`
 
 If you need to set back your dotnet new list to "factory defaults", use this command:
 


### PR DESCRIPTION
Was following the readme to install the templates and got the below error:


```
❯ dotnet new -i Duende.IdentityServer.Templates
  Determining projects to restore...
C:\Users\damian\.templateengine\dotnetcli\v3.1.403\scratch\restore.csproj : error NU1103: Unable to find a stable package Duende.IdentityServer.Templates with version (>= 0.0.0)
C:\Users\damian\.templateengine\dotnetcli\v3.1.403\scratch\restore.csproj : error NU1103:   - Found 1 version(s) in nuget.org [ Nearest version: 5.0.0-preview.1 ]
C:\Users\damian\.templateengine\dotnetcli\v3.1.403\scratch\restore.csproj : error NU1103:   - Found 0 version(s) in Microsoft Visual Studio Offline Packages
C:\Users\damian\.templateengine\dotnetcli\v3.1.403\scratch\restore.csproj : error NU1103:   - Found 0 version(s) in C:\Program Files\dotnet\sdk\NuGetFallbackFolder
  Failed to restore C:\Users\damian\.templateengine\dotnetcli\v3.1.403\scratch\restore.csproj (in 431 ms).
```

To install preview template version the exact version number needs to be specified.

This will need to be updated when a new preview or new stable version is published.

(An alternative to this PR is to just point to nuget.org which shows the up-to-date CLI instruction)