### PR TITLE
Fix #16: Rename IdentityServerHost namespace to match template name

### DIFF
--- a/src/IdentityServerAspNetIdentity/.template.config/template.json
+++ b/src/IdentityServerAspNetIdentity/.template.config/template.json
@@ -23,10 +23,20 @@
       "executable": "dotnet",
       "args": "run /seed"
     },
-    "manualInstructions": [{ 
-       "text": "Seeds the initial user database" 
-       }],
+    "manualInstructions": [{
+       "text": "Seeds the initial user database"
+    }],
     "continueOnError": "false",
     "description ": "seeds the database"
-  }]
+  }],
+  "symbols": {
+    "RenameCommonNamespace": {
+      "datatype": "string",
+      "displayName": "Fix common host namespace.",
+      "replaces": "IdentityServerHost",
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "safe_namespace"
+    }
+  }
 }

--- a/src/IdentityServerEntityFramework/.template.config/template.json
+++ b/src/IdentityServerEntityFramework/.template.config/template.json
@@ -23,10 +23,20 @@
       "executable": "dotnet",
       "args": "run /seed"
     },
-    "manualInstructions": [{ 
-       "text": "Seeds the initial database" 
-       }],
+    "manualInstructions": [{
+       "text": "Seeds the initial database"
+    }],
     "continueOnError": "false",
     "description ": "seeds the database"
-  }]
+  }],
+  "symbols": {
+    "RenameCommonNamespace": {
+      "datatype": "string",
+      "displayName": "Fix common host namespace.",
+      "replaces": "IdentityServerHost",
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "safe_namespace"
+    }
+  }
 }

--- a/src/IdentityServerInMem/.template.config/template.json
+++ b/src/IdentityServerInMem/.template.config/template.json
@@ -12,8 +12,18 @@
     "language": "C#",
     "type": "project"
   },
-  
+
   "sourceName": "IdentityServerInMem",
   "preferNameDirectory": "true",
-  "primaryOutputs": [ { "path": "IdentityServerInMem.csproj" } ]
+  "primaryOutputs": [ { "path": "IdentityServerInMem.csproj" } ],
+  "symbols": {
+    "RenameCommonNamespace": {
+      "datatype": "string",
+      "displayName": "Fix common host namespace.",
+      "replaces": "IdentityServerHost",
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "safe_namespace"
+    }
+  }
 }


### PR DESCRIPTION
This updates the templates that have `Pages` so that the string `IdentityServerHost` is replaced with the namespace version of whatever is specified for the template. Which is to say, if someone does

`dotnet new isinmem -n Foo.Bar`

then all the stuff under `Pages` will have the namespace `Foo.Bar.Pages` instead of `IdentityServerHost.Pages`.

It's a literal string search and replace, just like how the regular template replacement works, so if there is a string like `IdentityServerHostIsCool` then you'll end up with `Foo.BarIsCool` when it's all scaffolded out. However, I did test that with the changes it seems to scaffold out, build, and run fine. `IdentityServerHost` seemed reasonably long and unique enough to work.