### PR TITLE
Add bash scripts to generate migrations on a Unix operating system

### DIFF
--- a/src/IdentityServerAspNetIdentity/buildschema.sh
+++ b/src/IdentityServerAspNetIdentity/buildschema.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm -rf "Data/Migrations"
+
+dotnet ef migrations add Users -c ApplicationDbContext -o Data/Migrations

--- a/src/IdentityServerEntityFramework/buildschema.sh
+++ b/src/IdentityServerEntityFramework/buildschema.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+rm -rf Migrations
+
+dotnet ef migrations add Grants -c PersistedGrantDbContext -o Migrations/PersistedGrantDb
+dotnet ef migrations add Configuration -c ConfigurationDbContext -o Migrations/ConfigurationDb
+
+dotnet ef migrations script -c PersistedGrantDbContext -o Migrations/PersistedGrantDb.sql
+dotnet ef migrations script -c ConfigurationDbContext -o Migrations/ConfigurationDb.sql


### PR DESCRIPTION
This change will allow people to generate migrations on a Mac/Linux machine via `./buildschema.sh` in the two templates they are added.