### PR TITLE
Consistent X-Frame-Options and csp

### DIFF
--- a/src/IdentityServerAspNetIdentity/Pages/SecurityHeadersAttribute.cs
+++ b/src/IdentityServerAspNetIdentity/Pages/SecurityHeadersAttribute.cs
@@ -23,7 +23,7 @@ public class SecurityHeadersAttribute : ActionFilterAttribute
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
             if (!context.HttpContext.Response.Headers.ContainsKey("X-Frame-Options"))
             {
-                context.HttpContext.Response.Headers.Add("X-Frame-Options", "SAMEORIGIN");
+                context.HttpContext.Response.Headers.Add("X-Frame-Options", "DENY");
             }
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

--- a/src/IdentityServerEntityFramework/Pages/SecurityHeadersAttribute.cs
+++ b/src/IdentityServerEntityFramework/Pages/SecurityHeadersAttribute.cs
@@ -23,7 +23,7 @@ public class SecurityHeadersAttribute : ActionFilterAttribute
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
             if (!context.HttpContext.Response.Headers.ContainsKey("X-Frame-Options"))
             {
-                context.HttpContext.Response.Headers.Add("X-Frame-Options", "SAMEORIGIN");
+                context.HttpContext.Response.Headers.Add("X-Frame-Options", "DENY");
             }
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

--- a/src/IdentityServerInMem/Pages/SecurityHeadersAttribute.cs
+++ b/src/IdentityServerInMem/Pages/SecurityHeadersAttribute.cs
@@ -23,7 +23,7 @@ public class SecurityHeadersAttribute : ActionFilterAttribute
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
             if (!context.HttpContext.Response.Headers.ContainsKey("X-Frame-Options"))
             {
-                context.HttpContext.Response.Headers.Add("X-Frame-Options", "SAMEORIGIN");
+                context.HttpContext.Response.Headers.Add("X-Frame-Options", "DENY");
             }
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy


### PR DESCRIPTION
Use X-Frame-Options DENY to be consistent with csp frame-ancestors 'none'

See https://github.com/DuendeSoftware/Support/issues/715