### PR TITLE
Update to IdentityServer 7.0.4

### DIFF
--- a/src/BffLocalApi/BffLocalApi.csproj
+++ b/src/BffLocalApi/BffLocalApi.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="Duende.BFF.Yarp" Version="2.2.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.3" />
 	</ItemGroup>
 
 </Project>

--- a/src/IdentityServerAspNetIdentity/IdentityServerAspNetIdentity.csproj
+++ b/src/IdentityServerAspNetIdentity/IdentityServerAspNetIdentity.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.0.0" />
+		<PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.0.4" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
 
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />

--- a/src/IdentityServerAspNetIdentity/IdentityServerAspNetIdentity.csproj
+++ b/src/IdentityServerAspNetIdentity/IdentityServerAspNetIdentity.csproj
@@ -12,10 +12,10 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3" />
 	</ItemGroup>
 </Project>

--- a/src/IdentityServerEmpty/IdentityServerEmpty.csproj
+++ b/src/IdentityServerEmpty/IdentityServerEmpty.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer" Version="7.0.0" />
+		<PackageReference Include="Duende.IdentityServer" Version="7.0.4" />
 
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
 	</ItemGroup>

--- a/src/IdentityServerEntityFramework/IdentityServerEntityFramework.csproj
+++ b/src/IdentityServerEntityFramework/IdentityServerEntityFramework.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.0.0" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.0.4" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
 
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />

--- a/src/IdentityServerEntityFramework/IdentityServerEntityFramework.csproj
+++ b/src/IdentityServerEntityFramework/IdentityServerEntityFramework.csproj
@@ -12,9 +12,9 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/IdentityServerInMem/IdentityServerInMem.csproj
+++ b/src/IdentityServerInMem/IdentityServerInMem.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer" Version="7.0.0" />
+		<PackageReference Include="Duende.IdentityServer" Version="7.0.4" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Update the templates to reference IdentityServer 7.0.4 and ASP.NET 8.0.3, to avoid getting warnings about the wilson version out of the box.